### PR TITLE
Host api improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,6 +3275,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 name = "host_example"
 version = "0.0.3"
 dependencies = [
+ "anyhow",
  "bevy",
  "bevy-inspector-egui",
  "wasvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 publish = true
 
 [workspace]
-members = ["examples/host_example","examples/simple"]
+members = ["examples/host_example", "examples/simple"]
 resolver = "2"
 
 [workspace.package]

--- a/examples/host_example/Cargo.toml
+++ b/examples/host_example/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
-bevy = { version = "0.16.0", features = ["wayland", "dynamic_linking"]}
+anyhow = "1.0.98"
+bevy = { version = "0.16.0", features = ["wayland", "dynamic_linking"] }
 bevy-inspector-egui = "0.31.0"
 wasvy = { path = "../../" }

--- a/examples/host_example/src/main.rs
+++ b/examples/host_example/src/main.rs
@@ -1,57 +1,29 @@
 use bevy::prelude::*;
-use bevy::{DefaultPlugins, app::App, asset::AssetPlugin};
+use bevy::{DefaultPlugins, app::App};
 use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::WorldInspectorPlugin};
-use wasvy::asset::WasmComponentAsset;
-use wasvy::plugin::WasvyHostPlugin;
 
-/// Bevy drops assets if there are no active handles
-/// so this resource exists to keep the handles alive.
-#[derive(Resource)]
-struct WasmAssets {
-    #[allow(dead_code)]
-    pub assests: Vec<Handle<WasmComponentAsset>>,
-}
-
-struct ExamplePlugin;
-
-impl Plugin for ExamplePlugin {
-    fn build(&self, app: &mut App) {
-        app.add_systems(Startup, load_wasm_modules);
-    }
-}
-
-/// Before running the example build either `simple` or `python_example` from the examples folder
-/// and put the `.wasm` file in the host_example assets folder.
-///
-/// You can build either by using `just` (Checkout the `justfile` in the root of the repo)
-fn load_wasm_modules(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let simple_handle = asset_server.load::<WasmComponentAsset>("simple.wasm");
-
-    // It takes a few seconds for the python WASM to load.
-    // If there are no errors at runtime it means it's working, just give it 10-20 seconds.
-    let python_handle = asset_server.load::<WasmComponentAsset>("python.wasm");
-
-    commands.insert_resource(WasmAssets {
-        assests: vec![simple_handle, python_handle],
-    });
-}
+// Get started by importing the prelude
+use wasvy::prelude::*;
 
 fn main() {
-    let mut app = App::new();
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins((
+            // Next, add the [`ModloaderPlugin`] ;)
+            ModloaderPlugin,
+            // Plus some helpers for the example
+            EguiPlugin {
+                enable_multipass_for_primary_context: true,
+            },
+            WorldInspectorPlugin::new(),
+        ))
+        .add_systems(Startup, startup)
+        .run();
+}
 
-    app.add_plugins(DefaultPlugins.set(AssetPlugin {
-        watch_for_changes_override: Some(true),
-        ..Default::default()
-    }));
-    app.add_plugins(EguiPlugin {
-        enable_multipass_for_primary_context: true,
-    });
-    app.add_plugins(WorldInspectorPlugin::new());
-
-    // Adding the [`WasvyHostPlugin`] is all you need ;)
-    app.add_plugins(WasvyHostPlugin);
-
-    app.add_plugins(ExamplePlugin);
-
-    app.run();
+/// Access the modloader's api through the Mods interface
+fn startup(mut mods: Mods) {
+    // Load one (or several) mods at once from the asset directory!
+    mods.load("mods/simple.wasm");
+    mods.load("mods/python.wasm");
 }

--- a/examples/simple/src/bindings.rs
+++ b/examples/simple/src/bindings.rs
@@ -251,7 +251,6 @@ pub mod wasvy {
             /// So for every instance of `component` make sure you deserialize it yourself to the struct that it actually is.
             #[derive(Clone)]
             pub struct Component {
-                /// id: component-id,
                 pub path: _rt::String,
                 pub value: _rt::String,
             }

--- a/justfile
+++ b/justfile
@@ -1,12 +1,13 @@
 build-example example:
 	cargo component build --release -p {{example}}
+	cp ./target/wasm32-wasip1/release/{{example}}.wasm ./examples/assets/mods
 
 run-host-example:
-	cargo run -p host_example
+	cargo run -p host_example --features bevy/file_watcher
 
 # Requires `poetry` to run
 build-example-python:
-	cd examples/python_example/src/python_example && poetry run componentize-py --wit-path ../../wit/ --world guest componentize app -o ../../../../python.wasm
+	cd examples/python_example/src/python_example && poetry run componentize-py --wit-path ../../wit/ --world guest componentize app -o ../../../assets/mods/python.wasm
 
 # Create the bindings for the python example
 example-bindings-python:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod asset;
 pub mod component_registry;
 pub mod host;
+pub mod mods;
 pub mod plugin;
 pub mod prelude;
 pub mod runner;

--- a/src/mods.rs
+++ b/src/mods.rs
@@ -1,0 +1,40 @@
+use bevy::{asset::AssetPath, ecs::system::SystemParam, prelude::*};
+
+use crate::asset::WasmComponentAsset;
+
+/// This system param provides an interface to load and manage Wasvy mods
+#[derive(SystemParam)]
+pub struct Mods<'w, 's> {
+    commands: Commands<'w, 's>,
+    asset_server: Res<'w, AssetServer>,
+    mods: Query<'w, 's, Entity, With<Mod>>,
+}
+
+/// Bevy drops assets if there are no active handles
+/// so this component exists to keep the handles alive.
+#[derive(Component, Reflect)]
+struct Mod {
+    pub asset: Handle<WasmComponentAsset>,
+}
+
+impl Mods<'_, '_> {
+    /// Load a single wasm file from the given path.
+    pub fn load<'a>(&mut self, path: impl Into<AssetPath<'a>>) {
+        let path: AssetPath = path.into();
+        let name = path
+            .path()
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or("unknown".to_string());
+        let asset = self.asset_server.load::<WasmComponentAsset>(path);
+        self.commands.spawn((Name::new(name), Mod { asset }));
+    }
+
+    /// Unload all currently loaded mods.
+    pub fn clear(&mut self) {
+        for entity in self.mods.iter() {
+            self.commands.entity(entity).despawn();
+        }
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,4 @@
 pub use crate::asset::WasmComponentAsset;
 
-pub use crate::plugin::WasvyHostPlugin;
+pub use crate::mods::Mods;
+pub use crate::plugin::ModloaderPlugin;


### PR DESCRIPTION
This wraps up a small pr I started a few months back. Not very high prio, but I want to clean up the host example and establish some form of an api for loading and unloading mods that we can also use in tests.

Also adds some safety checks and warnings for developers first getting started.

Storing asset handles in components should work better for debugging and we can share weak handles with the systems in charge of executing wasm systems.